### PR TITLE
el9stream: Re-enable FIPS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -90,7 +90,6 @@ while [ $TRIES -gt 0 ]; do #try again once
         BUILD_ENGINE_INSTALLED= \
         BUILD_HE_INSTALLED= \
         OPENSCAP_PROFILE="${OPENSCAP_PROFILE}" \
-        USE_FIPS= \
         rpm
   elif [ $DISTRO = "rhel8" ]; then
     for i in rhel8-provision-engine.sh.in rhel8-provision-host.sh.in; do


### PR DESCRIPTION
FIPS should work now on el9stream.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>