### PR TITLE
el8stream-provision-host.sh.in still needs the workaround

### DIFF
--- a/el8stream-provision-host.sh.in
+++ b/el8stream-provision-host.sh.in
@@ -1,9 +1,10 @@
 #!/bin/bash -xe
 
-dnf copr enable -y ovirt/ovirt-master-snapshot
-dnf install -y \
-    dnf-utils \
-    ovirt-release-master
+# Workaround for https://bugzilla.redhat.com/2024629
+# dnf copr enable -y ovirt/ovirt-master-snapshot
+rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
+dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/ \
+    install -y dnf-utils ovirt-release-master
 
 dnf -y install \
     ovirt-host \

--- a/el9stream-provision-host.sh.in
+++ b/el9stream-provision-host.sh.in
@@ -1,1 +1,15 @@
-el8stream-provision-host.sh.in
+#!/bin/bash -xe
+
+dnf copr enable -y ovirt/ovirt-master-snapshot
+dnf install -y \
+    dnf-utils \
+    ovirt-release-master
+
+dnf -y install \
+    ovirt-host \
+    python3-coverage
+# We install NetworkManager-config-server by default with
+# vdsm which stops automatic DHCP assignments to interfaces.
+# We use that in OST deploy so let's just disable that
+# and let DHCP do its job
+rm "/usr/lib/NetworkManager/conf.d/00-server.conf"


### PR DESCRIPTION
This reverts acbc2ddf7065fd877d3e52a06ed094a531d1e0ad
