### PR TITLE
copr again

### DIFF
--- a/el8stream-provision-host.sh.in
+++ b/el8stream-provision-host.sh.in
@@ -1,10 +1,9 @@
 #!/bin/bash -xe
 
-# Workaround for https://bugzilla.redhat.com/2024629
-# dnf copr enable -y ovirt/ovirt-master-snapshot
-rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
-dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/ \
-    install -y dnf-utils ovirt-release-master
+dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-$(. /etc/os-release; echo ${VERSION_ID})
+dnf install -y \
+    dnf-utils \
+    ovirt-release-master
 
 dnf -y install \
     ovirt-host \

--- a/el9stream-provision-host.sh.in
+++ b/el9stream-provision-host.sh.in
@@ -1,15 +1,1 @@
-#!/bin/bash -xe
-
-dnf copr enable -y ovirt/ovirt-master-snapshot
-dnf install -y \
-    dnf-utils \
-    ovirt-release-master
-
-dnf -y install \
-    ovirt-host \
-    python3-coverage
-# We install NetworkManager-config-server by default with
-# vdsm which stops automatic DHCP assignments to interfaces.
-# We use that in OST deploy so let's just disable that
-# and let DHCP do its job
-rm "/usr/lib/NetworkManager/conf.d/00-server.conf"
+el8stream-provision-host.sh.in


### PR DESCRIPTION
- el8stream-provision-host.sh.in still needs the workaround
- el8stream-provision-host.sh.in: unify the dnf copr enable command
