### PR TITLE
Revert "el9stream: Re-enable FIPS"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -90,6 +90,7 @@ while [ $TRIES -gt 0 ]; do #try again once
         BUILD_ENGINE_INSTALLED= \
         BUILD_HE_INSTALLED= \
         OPENSCAP_PROFILE="${OPENSCAP_PROFILE}" \
+        USE_FIPS= \
         rpm
   elif [ $DISTRO = "rhel8" ]; then
     for i in rhel8-provision-engine.sh.in rhel8-provision-host.sh.in; do


### PR DESCRIPTION
The problem is fixed in u/s [1], but the change didn't land in el9stream
yet.

[1] https://gitlab.com/redhat/centos-stream/rpms/python3.9/-/merge_requests/21

This reverts commit 888f613252b46e28cc35df573100f05e66767258.