### PR TITLE
HE: Install the appliance from default repos

### DIFF
--- a/el8stream-provision-he.sh.in
+++ b/el8stream-provision-he.sh.in
@@ -1,4 +1,3 @@
 #!/bin/bash -xe
 dnf -y --nogpgcheck install ovirt-imageio-client
-# TODO use resources.ovirt.org until appliance is built in COPR or somewhere
-dnf -y --nogpgcheck --repo oea --repofrompath oea,https://resources.ovirt.org/repos/ovirt/tested/master/rpm/el8/ install ovirt-engine-appliance
+dnf -y --nogpgcheck install ovirt-engine-appliance


### PR DESCRIPTION
The appliance is now published by a github action, to a different place,
and ovirt-release correctly points there. So use that instead of
pointing to a specific repo.

Change-Id: I182a04e7e2598ddde8a78989cef422ff7de9d842
Signed-off-by: Yedidyah Bar David <didi@redhat.com>