### PR TITLE
Fix broken arguments passed to `virt-customize`

### DIFF
--- a/makefiles/engine-installed.mk
+++ b/makefiles/engine-installed.mk
@@ -16,7 +16,7 @@ cirros.img:
 		--run "$*-provision-engine.sh" \
 		$(_RESTORE_REGULAR_DNF_CACHE) \
 		--upload cirros.img:/var/tmp \
-		--run-command chown root:root /var/tmp/cirros.img \
+		--run-command "chown root:root /var/tmp/cirros.img" \
 		--run-command "rpm -qa | sort > $(_PKGLIST_PATH)/$(@:.qcow2=-pkglist.txt)" \
 		--run-command "setfiles -F -m -v $(SE_CONTEXT) $(PARTITIONS)" \
 		--selinux-relabel

--- a/makefiles/he-installed.mk
+++ b/makefiles/he-installed.mk
@@ -13,7 +13,7 @@
 		--run-command "dnf download --downloaddir /var/tmp sysstat lm_sensors-libs.x86_64" \
 		$(_RESTORE_REGULAR_DNF_CACHE) \
 		--upload cirros.img:/var/tmp \
-		--run-command chown root:root /var/tmp/cirros.img \
+		--run-command "chown root:root /var/tmp/cirros.img" \
 		--run-command "rpm -qa | sort > $(_PKGLIST_PATH)/$(@:.qcow2=-pkglist.txt)" \
 		--run-command "setfiles -F -m -v $(SE_CONTEXT) $(PARTITIONS)" \
 		--selinux-relabel


### PR DESCRIPTION
Entour the command with quotes.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
