### PR TITLE
refactor CentOS images caching

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,10 +19,16 @@ echo "with appliance: ${BUILD_HE_INSTALLED:=1}"
 echo "with node image url: ${NODE_URL_BASE:=https://resources.ovirt.org/repos/ovirt/github-ci/ovirt-node-ng-image/}"
 
 # cache CentOS images
-[[ -n "${CENTOS_CACHE_URL}" ]] && for i in CentOS.iso CentOS-Stream.iso CentOS-Stream-9.iso; do
-    echo "cache ${CENTOS_CACHE_URL}/$i"
-    curl $([[ -f $i ]] && echo -z $i) --fail --limit-rate 100M -O ${CENTOS_CACHE_URL}/$i || { echo Download of $i failed; rm -f $i; exit 1; }
-done
+declare -A INSTALL_URL
+INSTALL_URL[el8]="CentOS.iso"
+INSTALL_URL[el8stream]="CentOS-Stream.iso"
+INSTALL_URL[el9stream]="CentOS-Stream-9.iso"
+IMAGE=${INSTALL_URL[$DISTRO]}
+if [[ -n "${CENTOS_CACHE_URL}" && -n "$IMAGE" ]]; then
+    echo "cache $IMAGE"
+    curl $([[ -f $IMAGE ]] && echo "-z $IMAGE") --fail --limit-rate 100M -O ${CENTOS_CACHE_URL}/$IMAGE || { echo Download of $IMAGE failed; rm -f $IMAGE; exit 1; }
+fi
+
 # cache ovirt-node/rhvh image
 if [ $DISTRO = "rhvh" ]; then
     NODE_IMG=rhvh.iso
@@ -33,7 +39,7 @@ if [ $DISTRO = "rhvh" ]; then
     curl --fail -L -o $NODE_IMG $([[ -f $NODE_IMG ]] && echo -z $NODE_IMG) "${NODE_URL_BASE}/${LATEST}" || exit 1
 elif [ $DISTRO = "node" ]; then
     NODE_IMG=node.iso
-    # Latest ovirt-node as built by https://jenkins.ovirt.org/job/ovirt-node-ng-image_master_build-artifacts-el8-x86_64
+    # Latest ovirt-node as built by https://github.com/oVirt/ovirt-node-ng-image/actions/workflows/build.yml
     NODE_URL_DIST=el8
     NODE_URL_LATEST_VERSION=$(curl --fail "${NODE_URL_BASE}" | sed -n 's;.*a href="\(ovirt-node-ng-installer-[0-9.-]*.'$NODE_URL_DIST'.iso\)\".*;\1;p' | grep "\.${NODE_URL_DIST}\." | sort | tail -1)
     echo "latest node ${NODE_URL_BASE}${NODE_URL_LATEST_VERSION}"
@@ -62,7 +68,7 @@ while [ $TRIES -gt 0 ]; do #try again once
   if [ $DISTRO = "el8" ]; then
     time make \
         DISTRO=$DISTRO \
-        INSTALL_URL=../CentOS.iso \
+        INSTALL_URL=../$IMAGE \
         BUILD_BASE=1 \
         BUILD_HOST_INSTALLED=1 \
         BUILD_ENGINE_INSTALLED=1 \
@@ -73,7 +79,7 @@ while [ $TRIES -gt 0 ]; do #try again once
     time make \
         DISTRO=$DISTRO \
         REPO_ROOT=http://mirror.centos.org/centos/8-stream \
-        INSTALL_URL=../CentOS-Stream.iso \
+        INSTALL_URL=../$IMAGE \
         BUILD_BASE=1 \
         BUILD_HOST_INSTALLED=1 \
         BUILD_ENGINE_INSTALLED=1 \
@@ -84,7 +90,7 @@ while [ $TRIES -gt 0 ]; do #try again once
     time make \
         DISTRO=$DISTRO \
         REPO_ROOT=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/ \
-        INSTALL_URL=../CentOS-Stream-9.iso \
+        INSTALL_URL=../$IMAGE \
         BUILD_BASE=1 \
         BUILD_HOST_INSTALLED=1 \
         BUILD_ENGINE_INSTALLED= \


### PR DESCRIPTION
let's download just the one distro that's being built instead of all of
them. When building within a throw-awway container we only need the one.
