### PR TITLE
Drop auth in node/rhvh kickstart

### DIFF
--- a/node.ks.in
+++ b/node.ks.in
@@ -12,7 +12,7 @@ fi
 timezone --utc UTC
 lang en_US.UTF-8
 keyboard us
-auth --enableshadow --passalgo=sha512
+authselect minimal
 selinux --enforcing
 network --bootproto=dhcp
 firstboot --reconfig

--- a/node.ks.in
+++ b/node.ks.in
@@ -12,7 +12,6 @@ fi
 timezone --utc UTC
 lang en_US.UTF-8
 keyboard us
-authselect minimal
 selinux --enforcing
 network --bootproto=dhcp
 firstboot --reconfig


### PR DESCRIPTION
legacy "auth" is deprecated