### PR TITLE
autoconf: Add '--with-distro' option

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,15 +64,19 @@ prefix=/usr
 libdir=$prefix/lib64
 sysconfdir=/etc
 localstatedir=/var
-./configure --prefix=$prefix --libdir=$libdir --sysconfdir=$sysconfdir --localstatedir=$localstatedir
+./configure \
+    --prefix=$prefix \
+    --libdir=$libdir \
+    --sysconfdir=$sysconfdir \
+    --localstatedir=$localstatedir \
+    --with-distro=$DISTRO
 
 TRIES=2
 while [ $TRIES -gt 0 ]; do #try again once
-  make DISTRO=$DISTRO clean
+  make clean
   BUILD_WHAT="BUILD_BASE=1 BUILD_HOST_INSTALLED=1 BUILD_ENGINE_INSTALLED=1 BUILD_HE_INSTALLED=${BUILD_HE_INSTALLED}"
   if [ $DISTRO = "el8" ]; then
     time make \
-        DISTRO=$DISTRO \
         INSTALL_URL=../$IMAGE \
         BUILD_BASE=1 \
         BUILD_HOST_INSTALLED=1 \
@@ -82,7 +86,6 @@ while [ $TRIES -gt 0 ]; do #try again once
         rpm
   elif [ $DISTRO = "el8stream" ]; then
     time make \
-        DISTRO=$DISTRO \
         REPO_ROOT=http://mirror.centos.org/centos/8-stream \
         INSTALL_URL=../$IMAGE \
         BUILD_BASE=1 \
@@ -93,7 +96,6 @@ while [ $TRIES -gt 0 ]; do #try again once
         rpm
   elif [ $DISTRO = "el9stream" ]; then
     time make \
-        DISTRO=$DISTRO \
         REPO_ROOT=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/ \
         INSTALL_URL=../$IMAGE \
         BUILD_BASE=1 \
@@ -108,7 +110,6 @@ while [ $TRIES -gt 0 ]; do #try again once
         sed "s|%BUILD%|$RHEL8_BUILD|g" $i.in > $i
     done
     time make \
-        DISTRO=$DISTRO \
         REPO_ROOT=${RHEL8} \
         INSTALL_URL=${RHEL8}/BaseOS/x86_64/os/ \
         BUILD_BASE=1 \
@@ -120,7 +121,6 @@ while [ $TRIES -gt 0 ]; do #try again once
   elif [ $DISTRO = "node" -o $DISTRO = "rhvh" ]; then
     # REPO_ROOT is just where "other stuff" like rhvm-appliance comes from. Used only for rhvh.
     time make \
-        DISTRO=$DISTRO \
         REPO_ROOT=${RHVM_REPO} \
         INSTALL_URL=../$NODE_IMG \
         SPARSIFY_BASE=no \

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,27 @@ AM_INIT_AUTOMAKE([foreign])
 
 AC_SUBST([imagedir], ['${datarootdir}/ost-images'])
 
+AC_ARG_WITH(
+    [distro],
+    [AS_HELP_STRING(
+        [--with-distro=DISTRO],
+        [the distro that you want to build, @<:@default=el8stream@:>@]
+    )],
+    ,
+    [with_distro="el8stream"]
+)
+AC_SUBST([DISTRO], ["${with_distro}"])
+
+AC_CONFIG_COMMANDS(
+    [report],
+    [
+        echo "-----"
+        echo "----- Will build distro: $DISTRO"
+        echo "-----"
+    ],
+    [DISTRO=$with_distro]
+)
+
 AC_OUTPUT([
     Makefile
 ])

--- a/makefiles/vars.mk
+++ b/makefiles/vars.mk
@@ -1,6 +1,3 @@
-# This can be overriden by running with 'make DISTRO=...'
-DISTRO := el8stream
-
 # How many threads you want to use when xzipping RPMs
 XZ_NUM_THREADS := 4
 

--- a/ost-images.spec.in
+++ b/ost-images.spec.in
@@ -44,7 +44,7 @@ VM images needed to run OST
 %setup
 
 %build
-%configure
+%configure --with-distro=%{distro}
 
 %install
 %make_install


### PR DESCRIPTION
This patch adds '--with-distro' option to configure the desired
distro at the './configure' invocation level. With this change,
once a build is configured to use a specific distro, one does
not need to pass the 'DISTRO' var again to subsequent 'make'
commands (i.e. 'make DISTRO=mydistro clean').

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
