### PR TITLE
base: Remove support for builds based on top of existing base

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,10 +2,7 @@ include makefiles/constants.mk
 include makefiles/vars.mk
 include makefiles/pkglist.mk
 
-BASE_MAKEFILE := $(if $(BUILD_BASE),makefiles/built-base.mk,makefiles/preinstalled-base.mk)
-
-include $(BASE_MAKEFILE)
-
+include makefiles/base.mk
 include makefiles/engine-installed.mk
 include makefiles/host-installed.mk
 include makefiles/he-installed.mk
@@ -31,7 +28,7 @@ he: $(DISTRO)-he-installed.qcow2 $(DISTRO)-he-installed-pkglist.txt $(DISTRO)-he
 
 spec: ost-images.spec
 
-all: $(if $(BUILD_BASE),base) engine host he spec
+all: base engine host he spec
 
 gen-VERSION:
 	if test -d ../.git; then                                             \
@@ -45,11 +42,11 @@ clean-local:
 	virsh list --name --inactive | grep -q "^$(DISTRO)-base$$" && virsh undefine $(DISTRO)-base || :
 
 dist_image_DATA = \
-	$(if $(BUILD_BASE),$(DISTRO)-base-pkglist.txt) \
-	$(if $(BUILD_BASE),$(DISTRO)-base.qcow2) \
-	$(if $(BUILD_BASE),$(DISTRO).ks) \
-	$(if $(BUILD_BASE),$(DISTRO)_id_rsa) \
-	$(if $(BUILD_BASE),$(DISTRO)_id_rsa.pub) \
+	$(DISTRO)-base-pkglist.txt \
+	$(DISTRO)-base.qcow2 \
+	$(DISTRO).ks \
+	$(DISTRO)_id_rsa \
+	$(DISTRO)_id_rsa.pub \
 	$(if $(BUILD_ENGINE_INSTALLED),$(DISTRO)-engine-installed-pkglist-diff.txt) \
 	$(if $(BUILD_ENGINE_INSTALLED),$(DISTRO)-engine-installed-pkglist.txt) \
 	$(if $(BUILD_ENGINE_INSTALLED),$(DISTRO)-engine-installed.qcow2) \
@@ -95,8 +92,6 @@ rpm: spec
 		--define "distro $(DISTRO)" \
 		--define "release $(PACKAGE_RELEASE)" \
 		--define "xz_num_threads $(XZ_NUM_THREADS)" \
-		--define "with_base $(if $(BUILD_BASE),1,0)" \
-		$(if $(_BASE_IMAGE_VERSION),--define "base_version $(_BASE_IMAGE_VERSION)") \
 		--define "with_engine_installed $(if $(BUILD_ENGINE_INSTALLED),1,0)" \
 		--define "with_host_installed $(if $(BUILD_HOST_INSTALLED),1,0)" \
 		--define "with_he_installed $(if $(BUILD_HE_INSTALLED),1,0)" \

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,6 @@ include makefiles/pkglist.mk
 BASE_MAKEFILE := $(if $(BUILD_BASE),makefiles/built-base.mk,makefiles/preinstalled-base.mk)
 
 include $(BASE_MAKEFILE)
-include $(UPGRADE_MAKEFILE)
 
 include makefiles/engine-installed.mk
 include makefiles/host-installed.mk

--- a/build.sh
+++ b/build.sh
@@ -74,11 +74,10 @@ localstatedir=/var
 TRIES=2
 while [ $TRIES -gt 0 ]; do #try again once
   make clean
-  BUILD_WHAT="BUILD_BASE=1 BUILD_HOST_INSTALLED=1 BUILD_ENGINE_INSTALLED=1 BUILD_HE_INSTALLED=${BUILD_HE_INSTALLED}"
+  BUILD_WHAT="BUILD_HOST_INSTALLED=1 BUILD_ENGINE_INSTALLED=1 BUILD_HE_INSTALLED=${BUILD_HE_INSTALLED}"
   if [ $DISTRO = "el8" ]; then
     time make \
         INSTALL_URL=../$IMAGE \
-        BUILD_BASE=1 \
         BUILD_HOST_INSTALLED=1 \
         BUILD_ENGINE_INSTALLED=1 \
         BUILD_HE_INSTALLED=${BUILD_HE_INSTALLED} \
@@ -88,7 +87,6 @@ while [ $TRIES -gt 0 ]; do #try again once
     time make \
         REPO_ROOT=http://mirror.centos.org/centos/8-stream \
         INSTALL_URL=../$IMAGE \
-        BUILD_BASE=1 \
         BUILD_HOST_INSTALLED=1 \
         BUILD_ENGINE_INSTALLED=1 \
         BUILD_HE_INSTALLED=${BUILD_HE_INSTALLED} \
@@ -98,7 +96,6 @@ while [ $TRIES -gt 0 ]; do #try again once
     time make \
         REPO_ROOT=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/ \
         INSTALL_URL=../$IMAGE \
-        BUILD_BASE=1 \
         BUILD_HOST_INSTALLED=1 \
         BUILD_ENGINE_INSTALLED= \
         BUILD_HE_INSTALLED= \
@@ -112,7 +109,6 @@ while [ $TRIES -gt 0 ]; do #try again once
     time make \
         REPO_ROOT=${RHEL8} \
         INSTALL_URL=${RHEL8}/BaseOS/x86_64/os/ \
-        BUILD_BASE=1 \
         BUILD_HOST_INSTALLED=1 \
         BUILD_ENGINE_INSTALLED=1 \
         BUILD_HE_INSTALLED=${BUILD_HE_INSTALLED} \
@@ -125,7 +121,6 @@ while [ $TRIES -gt 0 ]; do #try again once
         INSTALL_URL=../$NODE_IMG \
         SPARSIFY_BASE=no \
         DISK_SIZE=80G \
-        BUILD_BASE=1 \
         BUILD_ENGINE_INSTALLED= \
         BUILD_HOST_INSTALLED= \
         BUILD_HE_INSTALLED= \

--- a/makefiles/base.mk
+++ b/makefiles/base.mk
@@ -21,14 +21,14 @@
 
 %-base.qcow2: $(if $(_USING_ISO), %.iso) %.ks
 	qemu-img create -f qcow2 $@.tmp $(DISK_SIZE)
-	# Qemu runs with lowered privileges so if the build
-	# is done by root, the image is created with 664
-	# permissions and qemu is unable to write to it.
-	# This is fixed on RPM level.
+#	Qemu runs with lowered privileges so if the build
+#	is done by root, the image is created with 664
+#	permissions and qemu is unable to write to it.
+#	This is fixed on RPM level.
 	chmod 666 $@.tmp
-	# node image build with the engine appliance needs lots of memory,
-	# also because we put dnf cache on tmpfs. 3072 MiB failed, 6144 worked.
-	# Didn't check what the minimum is currently.
+#	node image build with the engine appliance needs lots of memory,
+#	also because we put dnf cache on tmpfs. 3072 MiB failed, 6144 worked.
+#	Didn't check what the minimum is currently.
 	virt-install \
 		--name $(@:.qcow2=) \
 		--memory 6144 \
@@ -51,7 +51,7 @@
 				tail -20 ${CONSOLE_LOG}; \
 				exit 1; \
 			}
-	# Run customization common to all images
+#	Run customization common to all images
 	virt-customize \
 		-a $@.tmp \
 		--run provision-base.sh \

--- a/makefiles/preinstalled-base.mk
+++ b/makefiles/preinstalled-base.mk
@@ -1,5 +1,0 @@
-# If we're using preinstalled base image all we need to
-# do is to make a symlink of the qcow image in the build
-# directory.
-%-base.qcow2:
-	ln -s $(_BASE_IMAGE_PREFIX)$(*)-base.qcow2 $@

--- a/makefiles/vars.mk
+++ b/makefiles/vars.mk
@@ -25,24 +25,14 @@ USE_FIPS := yes
 # On/off switches for building layers. These options should have
 # sensible defaults i.e. if you have 'ost-images-el8-base' package installed,
 # then the default is not to build the base package.
-# Can be overriden by running with i.e. 'make BUILD_BASE=...'.
+# Can be overriden by running with i.e. 'make BUILD_HE_INSTALLED=...'.
 # Any non-empty string will be treated as true and an empty string is treated as false.
 # Only removing layers from the bottom is supported - you can't i.e.
 # build the "base" layer, but skip the "upgrade" layer.
-BUILD_BASE := $(if $(_USING_ISO),$(findstring not installed,$(shell rpm -q $(PACKAGE_NAME)-$(DISTRO)-base)),yes)
-
+BUILD_BASE := yes
 BUILD_ENGINE_INSTALLED := yes
 BUILD_HOST_INSTALLED := yes
 BUILD_HE_INSTALLED := yes
-
-# When using preinstalled images these point to prefixes
-# of installed RPMs (usually '/usr/share/ost-images'), otherwise
-# they're empty strings.
-_BASE_IMAGE_PREFIX := $(if $(BUILD_BASE),,$(shell rpm -q --queryformat '%{INSTPREFIXES}' $(PACKAGE_NAME)-$(DISTRO)-base)/$(PACKAGE_NAME)/)
-
-# When using preinstalled images these have the values of the RPM versions,
-# otherwise they're empty strings. We need these in the spec to define proper dependencies.
-_BASE_IMAGE_VERSION := $(if $(BUILD_BASE),,$(shell rpm -q --queryformat '%{VERSION}-%{RELEASE}' $(PACKAGE_NAME)-$(DISTRO)-base))
 
 # These variables point to scripts that provision "engine-installed"
 # and "host-installed" layers. Can be overriden by running with i.e. 'make PROVISION_HOST_SCRIPT=...'

--- a/ost-images.spec.in
+++ b/ost-images.spec.in
@@ -7,7 +7,6 @@
 %global _binary_payload w9T%{xz_num_threads}.xzdio
 
 # Whether certain RPMs are built or not
-%{!?with_base: %global with_base 0}
 %{!?with_engine_installed: %global with_engine_installed 0}
 %{!?with_host_installed: %global with_host_installed 0}
 %{!?with_he_installed: %global with_he_installed 0}
@@ -32,10 +31,7 @@ BuildRequires: make
 BuildRequires: qemu-img
 BuildRequires: virt-install
 
-# If we're building a layer by ourselves, this is simply the version
-# we use for all RPMs. If we're using a preinstalled layer,
-# this should match the preinstalled version.
-%{!?base_version: %global base_version %{version}-%{release}}
+%global base_version %{version}-%{release}
 
 %description
 VM images needed to run OST
@@ -48,9 +44,6 @@ VM images needed to run OST
 
 %install
 %make_install
-
-
-%if %{with_base}
 
 %package %{distro}-base
 Summary: Bare distro installation image with ssh key for root injected
@@ -65,7 +58,6 @@ Bare distro installation image with ssh key for root injected
 %attr(444, -, -) %{_datarootdir}/%{name}/*-base.qcow2
 %{_datarootdir}/%{name}/*-base-pkglist.txt
 
-%endif
 
 %if %{with_engine_installed}
 


### PR DESCRIPTION
base: Remove support for builds based on top of existing base

Until now we had the option to use an existing base image
(one installed along 'ost-images-DISTRO-base' RPM package)
as the foundation for all the other images. This made sense
when we were building CentOS 8 images with 'upgrade' layer
in between, but now we're working with rolling release distros
or nightly repos. Let's remove the logic that allowed that.
