### PR TITLE
el9: SELinux permissive policy for ovn

### DIFF
--- a/el9stream.ks.in
+++ b/el9stream.ks.in
@@ -78,6 +78,9 @@ echo "export HISTTIMEFORMAT='%F %T '" >> /etc/profile
 # write down which OpenSCAP profile is set
 echo -n "%OPENSCAP_PROFILE%" > /root/ost_images_openscap_profile
 
+# Permissive selinux for openvswitch BZ 2054323
+semanage permissive -a openvswitch_t
+
 # clean repo metadata for url-based builds
 dnf clean all
 


### PR DESCRIPTION
There is a SELinux policy blocking ovn permissions on el9.
We need to add a permissive policy to this context until this
bug is fixed.

https://bugzilla.redhat.com/show_bug.cgi?id=2054323