### PR TITLE
Enable fapolicyd again

### DIFF
--- a/provision-base.sh
+++ b/provision-base.sh
@@ -16,9 +16,6 @@ if [ -s /root/ost_images_openscap_profile ]; then
     # Ignored oscap rules for automatic testing
     ignored_oscap_rules=()
 
-    # Should be resolved by RHV eventually BZ#2021802
-    ignored_oscap_rules+=(xccdf_org.ssgproject.content_rule_service_fapolicyd_enabled)
-
     # OST has single DNS server
     ignored_oscap_rules+=(xccdf_org.ssgproject.content_rule_network_configure_name_resolution)
     # OST storage (/exports/nfs)

--- a/rhel8.ks.in
+++ b/rhel8.ks.in
@@ -73,12 +73,6 @@ sed -i 's/\(^GSSAPI[[:alpha:]]*\).*/\1 no/g;s/^#UseDNS.*/UseDNS no/g;' /etc/ssh/
 # Allow root login, needed by OST and host deploy
 sed -i 's/^PermitRootLogin no/PermitRootLogin yes/' /etc/ssh/sshd_config
 
-# fapolicyd
-# FIXME Temporary workaround until engine issues are resolved, one of:
-# 1) https://gerrit.ovirt.org/c/ovirt-engine/+/117373
-# 2) https://bugzilla.redhat.com/1902272
-systemctl disable fapolicyd
-
 # history
 echo "export HISTTIMEFORMAT='%F %T '" >> /etc/profile
 


### PR DESCRIPTION
The fapolicyd version needed by ovirt-engine (>=1.1),
should be available.

Signed-off-by: Ales Musil <amusil@redhat.com>