### PR TITLE
base: Ignore chronyd server check rule

### DIFF
--- a/provision-base.sh
+++ b/provision-base.sh
@@ -41,6 +41,8 @@ if [ -s /root/ost_images_openscap_profile ]; then
     ignored_oscap_rules+=(xccdf_org.ssgproject.content_rule_accounts_authorized_local_users)
     # SSSD needs to be configured manually
     ignored_oscap_rules+=(xccdf_org.ssgproject.content_rule_sssd_enable_certmap)
+    # Chronyd server directive needs to be configured manually
+    ignored_oscap_rules+=(xccdf_org.ssgproject.content_rule_chronyd_server_directive)
 
     # Based on https://github.com/ComplianceAsCode/content/blob/master/tests/ds_unselect_rules.sh
     DS=ssg-rhel8-ds.xml


### PR DESCRIPTION
The chronyd server check requires manual
remmediation.

Signed-off-by: Ales Musil <amusil@redhat.com>