### PR TITLE
el9stream: Use 'LEGACY' crypto policy

### DIFF
--- a/el9stream.ks.in
+++ b/el9stream.ks.in
@@ -78,6 +78,9 @@ echo "export HISTTIMEFORMAT='%F %T '" >> /etc/profile
 # write down which OpenSCAP profile is set
 echo -n "%OPENSCAP_PROFILE%" > /root/ost_images_openscap_profile
 
+# FIXME: COPR uses SHA-1 when signing packages (https://pagure.io/copr/copr/issue/2106)
+update-crypto-policies --set LEGACY
+
 # clean repo metadata for url-based builds
 dnf clean all
 


### PR DESCRIPTION
COPR is using SHA-1 when signing packages. SHA-1 is not supported
in el9stream's default crypto policy. Until [1] is resolved
we need to use 'LEGACY' crypto policy to work with el9stream.

[1] https://pagure.io/copr/copr/issue/2106

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
