### PR TITLE
base: Create connection files

### DIFF
--- a/configs/rhel8/rhel8.ks.in
+++ b/configs/rhel8/rhel8.ks.in
@@ -48,6 +48,7 @@ lvm2
 targetcli
 nfs-utils
 rpcbind
+uuid
 # for aaa tests from 389-ds module
 389-ds-base
 389-ds-base-legacy-tools

--- a/provision-base.sh
+++ b/provision-base.sh
@@ -8,6 +8,29 @@ ipv6.dhcp-duid=ll
 ipv6.dhcp-iaid=mac
 EOF
 
+# Create connection files for interfaces
+# All connections will have never-default=True except eth0
+for i in {0..5}; do
+  iface="eth$i"
+  cat << EOF > /etc/NetworkManager/system-connections/$iface
+[connection]
+id=$iface
+uuid=$(uuid)
+type=ethernet
+autoconnect=true
+interface-name=$iface
+
+[ipv6]
+method=auto
+never-default=$([ $i -gt 0 ] && echo "true" || echo "false")
+
+[ipv4]
+method=auto
+never-default=$([ $i -gt 0 ] && echo "true" || echo "false")
+EOF
+  chmod 600 /etc/NetworkManager/system-connections/$iface
+done
+
 # Cache security profile and adjust it for OST
 if [ -s /root/ost_images_openscap_profile ]; then
     # Download RHEL8 oscap XML needed by offline runs


### PR DESCRIPTION
In order to ensure that only eth0 will always be default
route create connection files. The "never-default=True" will
be applied to all interfaces except eth0.

Signed-off-by: Ales Musil <amusil@redhat.com>