### PR TITLE
Workflow for updating Selenium images on quay.io

### DIFF
--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -1,0 +1,29 @@
+name: Push latest Selenium images to quay
+
+on:
+  workflow_dispatch:
+  # Build every first day of the month at 00:00
+  schedule:
+    - cron:  '0 0 1 * *'
+env:
+  IMAGE_REGISTRY: quay.io
+jobs:
+  selenium-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [ node-chrome-debug, node-firefox-debug, hub, video ]
+    steps:
+      - name: Pull latest selenium images
+        run: podman pull docker.io/selenium/${{ matrix.image }}:latest
+      - name: Push to Quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: docker.io/selenium/${{ matrix.image }}
+          tags: latest
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME  }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - name: Print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
This patch introduces a workflow that pulls the latest Selenium
images from docker.io and publishes them on quay.io.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
