### PR TITLE
el9node: Add config

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -42,6 +42,13 @@ elif [ $DISTRO = "node" ]; then
     NODE_URL_LATEST_VERSION=$(curl --fail "${NODE_URL_BASE}" | sed -n 's;.*a href="\(ovirt-node-ng-installer-[0-9.-]*.'$NODE_URL_DIST'.iso\)\".*;\1;p' | grep "\.${NODE_URL_DIST}\." | sort | tail -1)
     echo "latest node ${NODE_URL_BASE}${NODE_URL_LATEST_VERSION}"
     curl --fail -L -o $NODE_IMG $([[ -f $NODE_IMG ]] && echo -z $NODE_IMG) ${NODE_URL_BASE}${NODE_URL_LATEST_VERSION} || exit 1
+elif [ $DISTRO = "el9node" ]; then
+    NODE_IMG=el9node.iso
+    # Latest ovirt-node as built by https://github.com/oVirt/ovirt-node-ng-image/actions/workflows/build.yml
+    NODE_URL_DIST=el9
+    NODE_URL_LATEST_VERSION=$(curl --fail "${NODE_URL_BASE}" | sed -n 's;.*a href="\(ovirt-node-ng-installer-[0-9.-]*.'$NODE_URL_DIST'.iso\)\".*;\1;p' | grep "\.${NODE_URL_DIST}\." | sort | tail -1)
+    echo "latest node ${NODE_URL_BASE}${NODE_URL_LATEST_VERSION}"
+    curl --fail -L -o $NODE_IMG $([[ -f $NODE_IMG ]] && echo -z $NODE_IMG) ${NODE_URL_BASE}${NODE_URL_LATEST_VERSION} || exit 1
 fi
 
 # validate OpenSCAP profile parameter

--- a/configs/el9node/build.env
+++ b/configs/el9node/build.env
@@ -1,0 +1,10 @@
+# See 'makefiles/vars.mk' for a list of variables that can be overriden
+# REPO_ROOT is just where "other stuff" like rhvm-appliance comes from. Used only for rhvh.
+export REPO_ROOT=${RHVM_REPO}
+export INSTALL_URL=../$NODE_IMG
+export SPARSIFY_BASE=no
+export DISK_SIZE=80G
+export BUILD_ENGINE_INSTALLED=
+export BUILD_HOST_INSTALLED=
+export BUILD_HE_INSTALLED=
+export OPENSCAP_PROFILE="${OPENSCAP_PROFILE}"

--- a/configs/el9node/el9node.ks.in
+++ b/configs/el9node/el9node.ks.in
@@ -1,0 +1,76 @@
+%pre
+cd /tmp
+if [ -e "/run/install/repo/ovirt-node-ng-image.squashfs.img" ]; then
+    ln -s /run/install/repo/ovirt-node-ng-image.squashfs.img /tmp/squashfs
+else
+    rpm2cpio /run/install/repo/Packages/redhat-virtualization-host-image-update*|cpio -ivd
+    squashfs=$(find|grep squashfs|grep -v meta)
+    ln -s $squashfs /tmp/squashfs
+fi
+%end
+
+timezone --utc UTC
+lang en_US.UTF-8
+keyboard us
+selinux --enforcing
+network --bootproto=dhcp
+firstboot --reconfig
+sshkey --username=root "%SSH_PUB_KEY%"
+rootpw --plaintext 123456
+poweroff
+clearpart --all --initlabel --disklabel=gpt
+autopart --type=thinp
+bootloader --timeout=1 --append="crashkernel=auto consoleblank=0 net.ifnames=0 console=ttyS0,115200n8"
+
+liveimg --url=file:///tmp/squashfs
+
+%OPENSCAP_PROFILE_SNIPPET%
+
+%post --erroronfail
+exec > /dev/ttyS0 2>&1
+set -ex
+imgbase --debug layout --init  >> /var/log/imgbased.log 2>&1
+
+# We install NetworkManager-config-server by default with
+# vdsm which stops automatic DHCP assignments to interfaces.
+# We use that in OST deploy so let's just disable that
+# and let DHCP do its job
+mkdir /tmp/rw_layer
+layer=/dev/$(lvs -ofullname | grep -o "[^ ].*+1")
+mount -onouuid "$layer" /tmp/rw_layer
+nsenter --root=/tmp/rw_layer rm -f /usr/lib/NetworkManager/conf.d/00-server.conf
+
+# Install also the appliance, to save time during setup.
+# Mount also /var* so that we keep dnf db/logs.
+vg=$(vgs --noheadings -ovg_name | grep -o '[^ ]*')
+mount -onouuid "/dev/${vg}/var" /tmp/rw_layer/var
+mount -onouuid "/dev/${vg}/var_log" /tmp/rw_layer/var/log
+mount -onouuid "/dev/${vg}/var_log_audit" /tmp/rw_layer/var/log/audit
+
+# Use a tmpfs filesystem for dnf cache. /dev/shm is not mounted at that point.
+mkdir -p /tmp/rw_layer/dnftmp
+mount -o size=4G -t tmpfs none /tmp/rw_layer/dnftmp
+nsenter --root=/tmp/rw_layer sed -i '$ a\cachedir=/dnftmp' /etc/dnf/dnf.conf
+source /etc/os-release
+if [ "$ID" = "rhel" ]; then
+    nsenter --root=/tmp/rw_layer dnf --repo=ostci --repofrompath ostci,%REPO_ROOT% --nogpgcheck install -y rhvm-appliance python3-coverage
+else
+    # --repo is mainly an optimization, also helps preventing some build failures -
+    # if they are due to other repos being inaccessible.
+    nsenter --root=/tmp/rw_layer dnf --repo=ovirt-\* --releasever=9 install -y ovirt-engine-appliance
+fi
+
+# write down which OpenSCAP profile is set
+nsenter --root=/tmp/rw_layer sh -c 'echo -n "%OPENSCAP_PROFILE%" > /root/ost_images_openscap_profile'
+
+nsenter --root=/tmp/rw_layer sed -i /^cachedir/d /etc/dnf/dnf.conf
+umount /tmp/rw_layer/dnftmp
+rmdir /tmp/rw_layer/dnftmp
+
+umount /tmp/rw_layer/var/log/audit
+umount /tmp/rw_layer/var/log
+umount /tmp/rw_layer/var
+umount /tmp/rw_layer
+rmdir /tmp/rw_layer
+
+%end


### PR DESCRIPTION
This patch adds config for building el9stream-based node images.
We don't have a python3-coverage package built for el9stream yet,
so OST runs with VDSM coverage enabled will fail, but we can work
on this later.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
