### PR TITLE
fix FIPS on el9

### DIFF
--- a/configs/el8stream/el8stream-provision-host.sh.in
+++ b/configs/el8stream/el8stream-provision-host.sh.in
@@ -13,6 +13,3 @@ dnf -y install \
 # We use that in OST deploy so let's just disable that
 # and let DHCP do its job
 rm "/usr/lib/NetworkManager/conf.d/00-server.conf"
-
-# TODO? FIPS is not set properly on el9 only
-[ "$(. /etc/os-release; echo ${VERSION_ID})" = "9" ] && update-crypto-policies --set FIPS || :

--- a/configs/el9stream/el9stream.ks.in
+++ b/configs/el9stream/el9stream.ks.in
@@ -78,9 +78,6 @@ echo "export HISTTIMEFORMAT='%F %T '" >> /etc/profile
 # write down which OpenSCAP profile is set
 echo -n "%OPENSCAP_PROFILE%" > /root/ost_images_openscap_profile
 
-# FIXME: COPR uses SHA-1 when signing packages (https://pagure.io/copr/copr/issue/2106)
-update-crypto-policies --set LEGACY
-
 # clean repo metadata for url-based builds
 dnf clean all
 


### PR DESCRIPTION
it was out workaround to set cryptopolicy to LEGACY. That issue is fixed
now and we can sue defaults.
