### PR TITLE
el9stream: add uuid package

### DIFF
--- a/configs/el9stream/el9stream.ks.in
+++ b/configs/el9stream/el9stream.ks.in
@@ -50,6 +50,7 @@ targetcli
 nfs-utils
 rpcbind
 policycoreutils-python-utils
+uuid
 # for aaa tests from 389-ds module
 # 389-ds-base
 # 389-ds-base-legacy-tools


### PR DESCRIPTION
we got it as a transient dependency on el8 but not anymore on el9