### PR TITLE
engine: Remove COPR workaround

### DIFF
--- a/configs/el8stream/el8stream-provision-engine.sh.in
+++ b/configs/el8stream/el8stream-provision-engine.sh.in
@@ -1,10 +1,6 @@
 #!/bin/bash -xe
 
-# Workaround for https://bugzilla.redhat.com/2024629
-# dnf copr enable -y ovirt/ovirt-master-snapshot
-rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
-dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/ \
-    install -y dnf-utils ovirt-release-master
+dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-$(. /etc/os-release; echo ${VERSION_ID})
 
 dnf module enable -y javapackages-tools pki-deps postgresql:12 mod_auth_openidc:2.3
 dnf -y install \


### PR DESCRIPTION
Specifying the COPR chroot explicitly is the valid way to go on both
el8stream and el9stream.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
