### PR TITLE
Introducing AlmaLinux 9 images

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,7 @@ echo "with node image url: ${NODE_URL_BASE:=https://resources.ovirt.org/repos/ov
 
 # cache CentOS images
 declare -A ISO_URL
+ISO_URL[alma9]="Alma.iso"
 ISO_URL[el8]="CentOS.iso"
 ISO_URL[el8stream]="CentOS-Stream.iso"
 ISO_URL[el9stream]="CentOS-Stream-9.iso"

--- a/configs/alma9/alma9-provision-he.sh.in
+++ b/configs/alma9/alma9-provision-he.sh.in
@@ -1,0 +1,1 @@
+../el9stream/el9stream-provision-he.sh.in

--- a/configs/alma9/alma9-provision-host.sh.in
+++ b/configs/alma9/alma9-provision-host.sh.in
@@ -1,0 +1,1 @@
+../el9stream/el9stream-provision-host.sh.in

--- a/configs/alma9/alma9.ks.in
+++ b/configs/alma9/alma9.ks.in
@@ -1,0 +1,1 @@
+../el9stream/el9stream.ks.in

--- a/configs/alma9/build.env
+++ b/configs/alma9/build.env
@@ -1,0 +1,7 @@
+# See 'makefiles/vars.mk' for a list of variables that can be overriden
+export REPO_ROOT=https://repo.almalinux.org/almalinux/9/
+export INSTALL_URL=../$IMAGE
+export BUILD_HOST_INSTALLED=1
+export BUILD_ENGINE_INSTALLED=
+export BUILD_HE_INSTALLED=${BUILD_HE_INSTALLED}
+export OPENSCAP_PROFILE="${OPENSCAP_PROFILE}"

--- a/configs/el8stream/el8stream-provision-engine.sh.in
+++ b/configs/el8stream/el8stream-provision-engine.sh.in
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-$(. /etc/os-release; echo ${VERSION_ID})
+dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-$(. /etc/os-release; echo ${VERSION_ID} | grep -o '^[0-9]')
 
 dnf module enable -y javapackages-tools pki-deps postgresql:12 mod_auth_openidc:2.3
 dnf -y install \

--- a/configs/el8stream/el8stream-provision-engine.sh.in
+++ b/configs/el8stream/el8stream-provision-engine.sh.in
@@ -1,10 +1,6 @@
 #!/bin/bash -xe
 
-# Workaround for https://bugzilla.redhat.com/2024629
-# dnf copr enable -y ovirt/ovirt-master-snapshot
-rpm --import https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/pubkey.gpg
-dnf --repofrompath=ovirt-master-snapshot,https://download.copr.fedorainfracloud.org/results/ovirt/ovirt-master-snapshot/centos-stream-8-x86_64/ \
-    install -y dnf-utils ovirt-release-master
+dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-$(. /etc/os-release; echo ${VERSION_ID})
 
 dnf module enable -y javapackages-tools pki-deps postgresql:12 mod_auth_openidc:2.3
 dnf -y install \

--- a/configs/el8stream/el8stream-provision-host.sh.in
+++ b/configs/el8stream/el8stream-provision-host.sh.in
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-$(. /etc/os-release; echo ${VERSION_ID})
+dnf copr enable -y ovirt/ovirt-master-snapshot centos-stream-$(. /etc/os-release; echo ${VERSION_ID} | grep -o '^[0-9]')
 dnf install -y \
     dnf-utils \
     ovirt-release-master


### PR DESCRIPTION
This patch provides initial config for AlmaLinux 9.

Similar to CentOS Stream 9, engine build is turned off at the moment.

On AlmaLinux 9 'VERSION_ID' takes a value of '9.0', so we need to trim
the string to match the COPR chroot name.
