### PR TITLE
authselect: Switch profile to 'sssd' with smart cards

### DIFF
--- a/configs/rhel8/rhel8.ks.in
+++ b/configs/rhel8/rhel8.ks.in
@@ -4,7 +4,7 @@ keyboard us
 rootpw  --plaintext 123456
 sshkey --username=root "%SSH_PUB_KEY%"
 firewall --service=ssh
-authselect select minimal
+authselect select sssd with-smartcard
 selinux --enforcing
 timezone --utc UTC
 network --bootproto=dhcp


### PR DESCRIPTION
DISA STIG openscap report is complaining about smart cards not being
enabled in relevant configuration files. Let's try using the 'sssd'
authselect profile with smart cards enabled.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
