### PR TITLE
el9node: add uuid package

### DIFF
--- a/configs/node/node.ks.in
+++ b/configs/node/node.ks.in
@@ -55,6 +55,7 @@ source /etc/os-release
 if [ "$ID" = "rhel" ]; then
     nsenter --root=/tmp/rw_layer dnf --repo=ostci --repofrompath ostci,%REPO_ROOT% --nogpgcheck install -y rhvm-appliance python3-coverage vdsm-hook-log-console
 else
+    nsenter --root=/tmp/rw_layer dnf --releasever=$VERSION --repo appstream install -y uuid
     nsenter --root=/tmp/rw_layer dnf --releasever=$VERSION --disableexcludes=all install -y ovirt-engine-appliance python3-coverage vdsm-hook-log-console
 fi
 


### PR DESCRIPTION
we use "uuid" in provision-base.sh, but on el9 it needs to be installed.
It was added in ae748771924a4f22e8f1f6357d45e5e4715a504d to regular
hosts but it's missing in node too.
