### PR TITLE
selenium: Go back to 4.0.0

### DIFF
--- a/configs/storage/setup_selenium_grid.sh
+++ b/configs/storage/setup_selenium_grid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
-CHROME_CONTAINER_IMAGE='quay.io/ovirt/selenium-standalone-chrome:4.4.0'
-FIREFOX_CONTAINER_IMAGE='quay.io/ovirt/selenium-standalone-firefox:4.4.0'
+CHROME_CONTAINER_IMAGE='quay.io/ovirt/selenium-standalone-chrome:4.0.0'
+FIREFOX_CONTAINER_IMAGE='quay.io/ovirt/selenium-standalone-firefox:4.0.0'
 FFMPEG_CONTAINER_IMAGE='quay.io/ovirt/selenium-video:latest'
 
 IMAGES=( \


### PR DESCRIPTION
The 4.4.0 Selenium version is more unstable than 4.0.0.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
