### PR TITLE
Update selenium workflow and provisioning script

### DIFF
--- a/.github/workflows/selenium.yml
+++ b/.github/workflows/selenium.yml
@@ -1,10 +1,13 @@
-name: Push latest Selenium images to quay
+name: Push Selenium images to quay
 
 on:
   workflow_dispatch:
-  # Build every first day of the month at 00:00
-  schedule:
-    - cron:  '0 0 1 * *'
+    inputs:
+      selenium_version:
+        required: true
+        type: string
+        default: "4.5.0"
+
 env:
   IMAGE_REGISTRY: quay.io
 jobs:
@@ -12,17 +15,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [ node-chrome-debug, node-firefox-debug, hub, video ]
+        image: [ standalone-chrome, standalone-firefox ]
+        tag: [ '${{ inputs.selenium_version }}' ]
+        include:
+          - image: video
+            tag: latest
     steps:
-      - name: Pull latest selenium images
-        run: podman pull docker.io/selenium/${{ matrix.image }}:latest
+      - name: Pull selenium images
+        run: podman pull docker.io/selenium/${{ matrix.image }}:${{ matrix.tag }}
       - name: Tag the image
-        run: podman tag docker.io/selenium/${{ matrix.image }}:latest ovirt/${{ matrix.image }}:latest
+        run: podman tag docker.io/selenium/${{ matrix.image }}:${{ matrix.tag }} ovirt/selenium-${{ matrix.image }}:latest
       - name: Push to Quay.io
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ovirt/${{ matrix.image }}
+          image: ovirt/selenium-${{ matrix.image }}
           tags: latest
           registry: ${{ env.IMAGE_REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME  }}

--- a/configs/storage/setup_selenium_grid.sh
+++ b/configs/storage/setup_selenium_grid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -xe
 
-CHROME_CONTAINER_IMAGE='quay.io/ovirt/selenium-standalone-chrome:4.0.0'
-FIREFOX_CONTAINER_IMAGE='quay.io/ovirt/selenium-standalone-firefox:4.0.0'
+CHROME_CONTAINER_IMAGE='quay.io/ovirt/selenium-standalone-chrome:latest'
+FIREFOX_CONTAINER_IMAGE='quay.io/ovirt/selenium-standalone-firefox:latest'
 FFMPEG_CONTAINER_IMAGE='quay.io/ovirt/selenium-video:latest'
 
 IMAGES=( \


### PR DESCRIPTION
In this PR we do an overhaul of things around Selenium:
- we remove the scheduled container build for now. We can consider
  bringing it here again if we manage to stabilize UI tests.
- we add a parameter to specify which Selenium version to use.
  Until now we were always pulling 'latest' and pushing to our own quay
  repo as 'latest'. With the change we pull the version specified by
  'selenium_version' parameter and push to our own quay repo as
  'latest'. This way, the provisioning script and OST side can always
  use 'latest' and we never have to sync those two again.
- the video image always uses 'latest' tag
- we update the names of pulled/push container names to reflect the
  reality

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
