### PR TITLE
rhel8: self-signed server for ovirt-engine nightly

### DIFF
--- a/configs/rhel8/rhel8-provision-engine.sh.in
+++ b/configs/rhel8/rhel8-provision-engine.sh.in
@@ -8,7 +8,7 @@ echo -e "[bob]\nname=bob\ngpgcheck=0\nenabled=1\nbaseurl=%RHEL8_BUILD%/el8" > bo
 dnf module enable -y postgresql:12 pki-deps
 popd
 
-dnf -y --nogpgcheck --setopt=*.module_hotfixes=1 install \
+dnf -y --nogpgcheck --setopt=*.module_hotfixes=1 --setopt=sslverify=0 install \
     otopi-debug-plugins \
     ovirt-engine \
     ovirt-engine-extension-aaa-ldap-setup \

--- a/configs/rhel8/rhel8-provision-he.sh.in
+++ b/configs/rhel8/rhel8-provision-he.sh.in
@@ -1,2 +1,2 @@
 #!/bin/bash -xe
-dnf -y --nogpgcheck install ovirt-engine-appliance ovirt-imageio-client
+dnf -y --nogpgcheck --setopt=sslverify=0 install ovirt-engine-appliance ovirt-imageio-client

--- a/configs/rhel8/rhel8-provision-host.sh.in
+++ b/configs/rhel8/rhel8-provision-host.sh.in
@@ -6,7 +6,7 @@ curl --fail -O %RHEL8_BUILD%/api/rhv_45_host.repo
 curl --fail -O %RHEL8_BUILD%/api/rhv_nightly.repo
 popd
 
-dnf -y --nogpgcheck install ovirt-host python3-coverage vdsm vdsm-hook-log-console
+dnf -y --nogpgcheck --setopt=sslverify=0 install ovirt-host python3-coverage vdsm vdsm-hook-log-console
 
 rm -f /usr/lib/NetworkManager/conf.d/00-server.conf
 


### PR DESCRIPTION
We started to use a server with self-signed certificates for
ovirt-engine nightly builds. Ignore it using sslverify=false.
