### PR TITLE
Downgrade openjdk to workaround keycloak setup issue

### DIFF
--- a/configs/el8stream/el8stream-provision-engine.sh.in
+++ b/configs/el8stream/el8stream-provision-engine.sh.in
@@ -13,3 +13,7 @@ dnf -y install \
     ovirt-engine-extension-aaa-ldap-setup \
     ovirt-log-collector \
     ovirt-imageio-client
+
+# Downgrade java-11-openjdk-headless to workaround following issue during keycloak setup
+# 'Failed to load truststore: /etc/pki/ovirt-engine/.truststore'
+dnf -y java-11-openjdk-headless-11.0.15.0.10-3.el8


### PR DESCRIPTION
Downgrade java-11-openjdk-headless to 11.0.15.0.10-3 to workaround
following error during keycloak setup:

 Failed to load truststore: /etc/pki/ovirt-engine/.truststore

Signed-off-by: Martin Perina <mperina@redhat.com>
