### PR TITLE
jenkins timing issue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,8 @@ fi
 
 
 pushd ost-images
+# bleh, due to the way jenkins jobs are chained there's a timing issue with archiving the results, if we run a new build right after the previous one the artifacts may not have been copied just yet. It's idiotic, but let's just wait a little...2 minutes ought to be enough for anyone.
+sleep 120
 rm -rf rpmbuild/RPMS/*
 [ -d /var/tmp ] && export TMPDIR=/var/tmp #virt-sparsify
 


### PR DESCRIPTION
due to the way jenkins jobs are chained there's a timing issue with
archiving the results, if we run a new build right after the previous
one the artifacts may not have been copied just yet. It's idiotic, but
let's just wait a little...2 minutes ought to be enough for anyone.
