### PR TITLE
Add vdsm-hook-log-firmware hook to hosts

### DIFF
--- a/configs/el8stream/el8stream-provision-host.sh.in
+++ b/configs/el8stream/el8stream-provision-host.sh.in
@@ -8,7 +8,8 @@ dnf install -y \
 dnf -y install \
     ovirt-host \
     python3-coverage \
-    vdsm-hook-log-console
+    vdsm-hook-log-console \
+    vdsm-hook-log-firmware
 # We install NetworkManager-config-server by default with
 # vdsm which stops automatic DHCP assignments to interfaces.
 # We use that in OST deploy so let's just disable that

--- a/configs/node/node.ks.in
+++ b/configs/node/node.ks.in
@@ -53,10 +53,10 @@ mount -o size=4G -t tmpfs none /tmp/rw_layer/dnftmp
 nsenter --root=/tmp/rw_layer sed -i '$ a\cachedir=/dnftmp' /etc/dnf/dnf.conf
 source /etc/os-release
 if [ "$ID" = "rhel" ]; then
-    nsenter --root=/tmp/rw_layer dnf --repo=ostci --repofrompath ostci,%REPO_ROOT% --nogpgcheck install -y rhvm-appliance python3-coverage vdsm-hook-log-console
+    nsenter --root=/tmp/rw_layer dnf --repo=ostci --repofrompath ostci,%REPO_ROOT% --nogpgcheck install -y rhvm-appliance python3-coverage vdsm-hook-log-console vdsm-hook-log-firmware
 else
     nsenter --root=/tmp/rw_layer dnf --releasever=$VERSION --repo appstream install -y uuid
-    nsenter --root=/tmp/rw_layer dnf --releasever=$VERSION --disableexcludes=all install -y ovirt-engine-appliance python3-coverage vdsm-hook-log-console
+    nsenter --root=/tmp/rw_layer dnf --releasever=$VERSION --disableexcludes=all install -y ovirt-engine-appliance python3-coverage vdsm-hook-log-console vdsm-hook-log-firmware
 fi
 
 # write down which OpenSCAP profile is set

--- a/configs/rhel8/rhel8-provision-host.sh.in
+++ b/configs/rhel8/rhel8-provision-host.sh.in
@@ -6,7 +6,7 @@ curl --fail -O %RHEL8_BUILD%/api/rhv_45_host.repo
 curl --fail -O %RHEL8_BUILD%/api/rhv_nightly.repo
 popd
 
-dnf -y --nogpgcheck --setopt=sslverify=0 install ovirt-host python3-coverage vdsm vdsm-hook-log-console
+dnf -y --nogpgcheck --setopt=sslverify=0 install ovirt-host python3-coverage vdsm vdsm-hook-log-console vdsm-hook-log-firmware
 
 rm -f /usr/lib/NetworkManager/conf.d/00-server.conf
 


### PR DESCRIPTION
Problems with nested VMs' firmware are hard to debug. A dump of firmware
log is very helpful with that, so let's have it on by default in OST.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
