### PR TITLE
ost-images: move cirros.img

### DIFF
--- a/configs/el9stream/el9stream-provision-engine.sh.in
+++ b/configs/el9stream/el9stream-provision-engine.sh.in
@@ -12,3 +12,5 @@ dnf -y install \
     ovirt-log-collector \
     ovirt-imageio-client
 
+mkdir /usr/share/ovirt-system-tests
+

--- a/makefiles/engine-installed.mk
+++ b/makefiles/engine-installed.mk
@@ -11,8 +11,8 @@
 		$(_CHANGE_DNF_CACHE_TO_DEV_SHM) \
 		--run "$*-provision-engine.sh" \
 		$(_RESTORE_REGULAR_DNF_CACHE) \
-		--upload cirros.img:/var/tmp \
-		--run-command "chown root:root /var/tmp/cirros.img" \
+		--upload cirros.img:/usr/share/ovirt-system-tests \
+		--run-command "chown root:root /usr/share/ovirt-system-tests/cirros.img" \
 		--run-command "rpm -qa | sort > $(_PKGLIST_PATH)/$(@:.qcow2=-pkglist.txt)" \
 		--run-command "setfiles -F -m -v $(SE_CONTEXT) $(PARTITIONS)" \
 		--selinux-relabel


### PR DESCRIPTION
By default files in /var/tmp are removed if they haven't been accessed for 30 days. So, if you run ost with images older then those 30 days the cirros image is cleaned up automatically. To mitigate this we move the image to /usr/share/ovirt-system-tests.