### PR TITLE
config: install the correct version of appliance

### DIFF
--- a/configs/el9stream/el9stream-provision-he.sh.in
+++ b/configs/el9stream/el9stream-provision-he.sh.in
@@ -1,5 +1,8 @@
 #!/bin/bash -xe
 dnf -y --nogpgcheck install ovirt-imageio-client
-dnf -y --nogpgcheck install ovirt-engine-appliance
+
+. /etc/os-release
+MAJOR_VERSION=$(echo ${VERSION_ID} | cut -d. -f1)
+dnf -y --nogpgcheck install ovirt-engine-appliance-${ID}${MAJOR_VERSION}
 
 mkdir /usr/share/ovirt-system-tests

--- a/configs/node/node.ks.in
+++ b/configs/node/node.ks.in
@@ -52,8 +52,9 @@ mkdir -p /tmp/rw_layer/dnftmp
 mount -o size=4G -t tmpfs none /tmp/rw_layer/dnftmp
 nsenter --root=/tmp/rw_layer sed -i '$ a\cachedir=/dnftmp' /etc/dnf/dnf.conf
 source /etc/os-release
+MAJOR_VERSION=$(echo ${VERSION_ID} | cut -d. -f1)
 nsenter --root=/tmp/rw_layer dnf --releasever=$VERSION --repo appstream install -y uuid
-nsenter --root=/tmp/rw_layer dnf --releasever=$VERSION --disableexcludes=all install -y ovirt-engine-appliance python3-coverage vdsm-hook-log-console vdsm-hook-log-firmware
+nsenter --root=/tmp/rw_layer dnf --releasever=$VERSION --disableexcludes=all install -y ovirt-engine-appliance-${ID}${MAJOR_VERSION} python3-coverage vdsm-hook-log-console vdsm-hook-log-firmware
 
 # write down which OpenSCAP profile is set
 nsenter --root=/tmp/rw_layer sh -c 'echo -n "%OPENSCAP_PROFILE%" > /root/ost_images_openscap_profile'


### PR DESCRIPTION
The new ovirt-engine-appliance comes in a flavour per distro. Dynamically determine the DISTRO and MAJOR_VERSION to install the correct appliance package.